### PR TITLE
Travis skip cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
 - yarn build-storybook
 deploy:
   provider: firebase
+  skip_cleanup: true
 after_success:
 - npm run report-coverage
 notifications:


### PR DESCRIPTION
Travis would build, then delete the build, and finally deploy nothing.
skip_cleanup disables workspace delete prior to deploy
