### PR TITLE
* fix #189 -  …

### DIFF
--- a/src/Kodetre/Kodeliste/ResultatListe.js
+++ b/src/Kodetre/Kodeliste/ResultatListe.js
@@ -112,18 +112,38 @@ class ResultatListe extends Component {
     )
   }
 
-  static highlightMatch(navn, query) {
-    if (!query) return navn
-    const q = query.toLowerCase().split(' ')[0]
-    const offset = navn.toLowerCase().indexOf(q)
-    if (offset < 0) return navn
+  // Highlight all matches
+  static highlightMatch(text, higlight) {
+    // make array of terms, ordered by longest term
+    let terms = higlight
+      .toLowerCase()
+      .split(' ')
+      .sort(function(a, b) {
+        return b.length - a.length
+      })
+    // make regex OR filter by concatenating terms with |
+    let filter = terms
+      .toString()
+      .toLowerCase()
+      .replace(/,/g, '|')
 
-    const end = offset + q.length
+    // Split on all terms and also include the terms into parts array, ignore case
+    let parts = text.split(new RegExp(`(${filter})`, 'gi'))
     return (
       <React.Fragment>
-        {navn.substring(0, offset)}
-        <span style={{ color: 'black' }}>{navn.substring(offset, end)}</span>
-        {navn.substring(end, navn.length)}
+        {' '}
+        {parts.map((part, i) => (
+          <span
+            key={i}
+            style={
+              terms.indexOf(part.toLowerCase()) >= 0
+                ? { color: 'black', fontWeight: 'bold' }
+                : {}
+            }
+          >
+            {part}
+          </span>
+        ))}{' '}
       </React.Fragment>
     )
   }

--- a/src/Kodetre/Kodeliste/__snapshots__/ResultatListe.test.js.snap
+++ b/src/Kodetre/Kodeliste/__snapshots__/ResultatListe.test.js.snap
@@ -2,16 +2,25 @@
 
 exports[`Highlight 1`] = `
 <Unknown>
-  
+   
+  <span
+    style={Object {}}
+  />
   <span
     style={
       Object {
         "color": "black",
+        "fontWeight": "bold",
       }
     }
   >
     Ka
   </span>
-  rmøy
+  <span
+    style={Object {}}
+  >
+    rmøy
+  </span>
+   
 </Unknown>
 `;

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -5606,7 +5606,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="KA"
@@ -5628,7 +5634,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -5638,7 +5650,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -5764,7 +5782,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -5786,7 +5810,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -5796,7 +5826,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -5892,7 +5928,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -5914,7 +5956,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -5924,7 +5972,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6020,7 +6074,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6042,7 +6102,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6052,7 +6118,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6148,7 +6220,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6170,7 +6248,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6180,7 +6264,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6276,7 +6366,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6298,7 +6394,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6308,7 +6410,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6404,7 +6512,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6426,7 +6540,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6436,7 +6556,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6532,7 +6658,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6554,7 +6686,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6564,7 +6702,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6660,7 +6804,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6682,7 +6832,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6692,7 +6848,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6788,7 +6950,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6810,7 +6978,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6820,7 +6994,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>
@@ -6916,7 +7096,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </div>
                         <img
                             alt="AR"
@@ -6938,7 +7124,13 @@ Array [
                             }
                         />
                         <span>
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                          
                         <span
@@ -6948,7 +7140,13 @@ Array [
                                   }
                             }
                         >
-                            
+                             
+                            <span
+                                style={Object {}}
+                            >
+                                
+                            </span>
+                             
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
highlighter alle termer men prioriterer lengste term så hvis en kort term overlapper delvis med en lang blir bare den lange markert

## A picture tells a thousand words

## Before this PR
![image](https://user-images.githubusercontent.com/13641108/37821344-a2fdc5f8-2e83-11e8-91ff-d0b0767af63e.png)

## After this PR
![image](https://user-images.githubusercontent.com/13641108/37821211-56889ad6-2e83-11e8-89ad-857c49efe51e.png)
![image](https://user-images.githubusercontent.com/13641108/37821282-78b06ab2-2e83-11e8-9c4c-c7cff30d8bde.png)
![image](https://user-images.githubusercontent.com/13641108/37821312-892726e2-2e83-11e8-8fd1-d4d157d8df85.png)
