### PR TITLE
fix #183: fjern opplyst/hover-lag også når man endrer aktivt

### DIFF
--- a/src/Kart/Mapbox/index.js
+++ b/src/Kart/Mapbox/index.js
@@ -94,6 +94,7 @@ class Mapbox extends Component {
       return
     }
     map.removeLayer('aktivt')
+    map.removeLayer('opplyst') // fjern opplyst/hover-lag også når man endrer aktivt
     //console.log('fjernet aktivt')
 
     if (aktivKode) {

--- a/src/Kodetre/Kodeliste/KodeVindu.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.js
@@ -1,8 +1,7 @@
 import MediaQuery from 'react-responsive'
 import React from 'react'
 import Kodekort from './Kodekort'
-import StatistikkContainer from '../Statistikk/StatistikkContainer'
-import { Paper, List, div, Subheader } from 'material-ui'
+import { Paper, List, div } from 'material-ui'
 import FetchContainer from '../../FetchContainer'
 import Kodeliste from './Kodeliste'
 import { RaisedButton } from 'material-ui'
@@ -34,7 +33,6 @@ class KodeVindu extends React.Component {
 
   render() {
     const props = this.props
-    const selv = props.meta.selv || {}
     const avatarUtenRamme = props.meta.utenRamme
     return (
       <FetchContainer>
@@ -142,12 +140,7 @@ class KodeVindu extends React.Component {
                     undertittel: { nb: 'Definisjon' },
                   },
                 }}
-                ekspandertKode={this.state.ekspandertKode}
                 onGoToCode={props.onGoToCode}
-                onMouseEnter={props.onMouseEnter}
-                onMouseLeave={props.onMouseLeave}
-                onShowColorpicker={this.handleShowColorpicker}
-                onUpdateLayerProp={props.onUpdateLayerProp}
                 language={props.language}
               />
             )}
@@ -160,11 +153,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med gjennomsnittlig dekning eller biomasseandel større enn 1/8 i et utvalg av enkeltobservasjonsenheter.`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.mengdeart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -177,11 +166,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med gjennomsnittlig dekning eller biomasseandel større enn 1/4 i et utvalg av enkeltobservasjonsenheter.`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.dominerende_mengdeart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -194,11 +179,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med frekvens større enn 1/8 i et utvalg enkeltobservasjonsenheter. For at en art skal være «vanlig», må den tilfredsstille dette kravet om frekvens > 1/8 i hele naturtypens utbredelsesområde, ikke bare innenfor artens utbredelsesområde.`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.vanlig_art}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -211,11 +192,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med frekvens større enn 4/5 i et utvalg enkeltobservasjonsenheter. Dette er den klassiske definisjonen av «konstant»  som er brukt i vegetasjonsøkologi`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.konstant_art}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -229,11 +206,7 @@ class KodeVindu extends React.Component {
                   (f.eks. andre hovedtyper som tilhører samme hovedtypegruppe eller andre grunntyper som tilhører samme hovedtype`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.tyngdepunktart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -246,11 +219,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med høyere frekvens og dekning på et gitt trinn langs en lokal kompleks miljøgradient (LKMg) enn på ethvert annet trinn langs den samme LKMg (gitt at variasjonen langs alle andre lokale komplekse miljøvariabler holdes konstant`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon['gradient-tyngdepunktart']}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -263,11 +232,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Tyngdepunktart som utelukkende eller nesten utelukkende forekommer i en naturtype eller gruppe av naturtyper på et eller annet generaliseringsnivå`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.kjennetegnende_tyngdepunktart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -280,11 +245,7 @@ class KodeVindu extends React.Component {
                   subtitle={`Art med høyere frekvens og/eller dekning i én av to eller flere naturtyper som sammenliknes. For skillearter angis hvilke basistrinn langs hvilke LKM’er de er skillearter for, på en standardisert måte. F.eks. betyr «absolutt skilleart[UF∙f|g]» at arten er absolutt skilleart for uttørkingsfare (UF) basistrinn f mot basistrinn g.`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.skilleart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
@@ -297,24 +258,10 @@ class KodeVindu extends React.Component {
                   subtitle={`Art som normalt bare forekommer i én blant to eller flere naturtyper som sammenliknes`}
                   apidata={props.data ? props.data.barn : []}
                   metadata={props.meta.relasjon.absolutt_skilleart}
-                  ekspandertKode={this.state.ekspandertKode}
                   onGoToCode={props.onGoToCode}
-                  onMouseEnter={props.onMouseEnter}
-                  onMouseLeave={props.onMouseLeave}
-                  onUpdateLayerProp={props.onUpdateLayerProp}
                   language={props.language}
                 />
               )}
-
-            {false && (
-              <React.Fragment>
-                <Subheader>Om {selv.tittel}</Subheader>
-                <StatistikkContainer
-                  ingress={props.meta.ingress}
-                  dataUrl={'/kode/' + props.data.kode}
-                />
-              </React.Fragment>
-            )}
           </List>
         </Paper>
       </FetchContainer>

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -10,42 +10,23 @@ var api = {
   antallArter: 11,
   antallNaturomrader: 247,
   areal: 21740243.9505291,
-  størsteAreal: 2174024,
   forelder: { kode: 'NA', navn: 'Naturområder' },
   barn: [
-    {
-      kode: 'NA_H1',
-      navn: 'Havvannmasser',
-      antallArter: 11,
-      antallNaturomrader: 0,
-      areal: 413230,
-      harBarn: true,
-    },
+    { kode: 'NA_H1', navn: 'Havvannmasser', antallArter: 11, harBarn: true },
     {
       kode: 'NA_H2',
       navn: 'Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster',
       antallArter: 10,
       antallNaturomrader: 247,
-      areal: 2174024,
+      areal: 21740243.9505291,
       harBarn: true,
     },
     {
       kode: 'NA_H3',
       navn:
         'Ikke-sirkulerende marine vannmasser i fysisk avgrensede saltvannsforekomster',
-      antallArter: 0,
-      antallNaturomrader: 0,
-      areal: 1414410,
-      harBarn: false,
     },
-    {
-      kode: 'NA_H4',
-      navn: 'Sterkt endrete marine vannmasser',
-      antallArter: 0,
-      antallNaturomrader: 0,
-      areal: 1666444,
-      harBarn: false,
-    },
+    { kode: 'NA_H4', navn: 'Sterkt endrete marine vannmasser' },
   ],
 }
 

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -105,7 +105,7 @@ storiesOf('KodeVindu', module)
       onMouseEnter={action('mouseEnter')}
       onMouseLeave={action('mouseLeave')}
       onClick={action('click')}
-      onShowColorpicker={action('showColorpicker')}
+      onFitBounds={action('onFitBounds')}
       language={['nb', 'la']}
     />
   ))

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -52,47 +52,47 @@ var api = {
 const meta = {
   barn: {
     NA_H1: {
-      farge: '#abdda4',
+      farge: '#f46d43',
       kode: 'NA_H1',
+      sti: 'NA/H/1',
       tittel: { nb: 'Havvannmasser' },
-      url: 'NA/H/1',
     },
     NA_H2: {
-      farge: '#f46d43',
+      farge: '#fdae61',
       kode: 'NA_H2',
+      sti: 'NA/H/2',
       tittel: {
         nb: 'Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster',
       },
-      url: 'NA/H/2',
     },
     NA_H3: {
       farge: '#fee08b',
       kode: 'NA_H3',
+      sti: 'NA/H/3',
       tittel: {
         nb:
           'Ikke-sirkulerende marine vannmasser i fysisk avgrensede saltvannsforekomster',
       },
-      url: 'NA/H/3',
     },
     NA_H4: {
-      farge: '#abdda4',
+      farge: '#e6f598',
       kode: 'NA_H4',
+      sti: 'NA/H/4',
       tittel: { nb: 'Sterkt endrete marine vannmasser' },
-      url: 'NA/H/4',
     },
   },
-  infoUrl: 'https://www.artsdatabanken.no/NiN2.0/F1',
   bbox: [[5.176, 58.107], [28.857, 70.144]],
-  farge: '#e6f598',
+  farge: '#d53e4f',
+  infoUrl: 'https://www.artsdatabanken.no/NiN2.0/H',
   ingress:
     'Marine vannmasser omfatter økosystemer av flytende, svevende og svømmende organismer i de frie vannmassene i saltvann (saltholdighet > 0,5 ‰)\n',
   kode: 'NA_H',
   overordnet: [
-    { kode: 'NA', tittel: { nb: 'Natursystem' }, url: 'NA' },
-    { kode: '~', tittel: { nb: 'Økologisk grunnkart' }, url: '' },
+    { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
+    { kode: '~', sti: '', tittel: { nb: 'Økologisk grunnkart' } },
   ],
+  sti: 'NA/H',
   tittel: { nb: 'Marine vannmasser' },
-  url: 'NA/H',
 }
 
 storiesOf('KodeVindu', module)

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -32,19 +32,11 @@ var api = {
 
 const meta = {
   barn: {
-    NA_H1: {
-      farge: '#f46d43',
-      kode: 'NA_H1',
-      sti: 'NA/H/1',
-      tittel: { nb: 'Havvannmasser' },
-    },
-    NA_H2: {
-      farge: '#fdae61',
-      kode: 'NA_H2',
-      sti: 'NA/H/2',
-      tittel: {
-        nb: 'Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster',
-      },
+    NA_H4: {
+      farge: '#e6f598',
+      kode: 'NA_H4',
+      sti: 'NA/H/4',
+      tittel: { nb: 'Sterkt endrete marine vannmasser' },
     },
     NA_H3: {
       farge: '#fee08b',
@@ -55,11 +47,19 @@ const meta = {
           'Ikke-sirkulerende marine vannmasser i fysisk avgrensede saltvannsforekomster',
       },
     },
-    NA_H4: {
-      farge: '#e6f598',
-      kode: 'NA_H4',
-      sti: 'NA/H/4',
-      tittel: { nb: 'Sterkt endrete marine vannmasser' },
+    NA_H2: {
+      farge: '#fdae61',
+      kode: 'NA_H2',
+      sti: 'NA/H/2',
+      tittel: {
+        nb: 'Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster',
+      },
+    },
+    NA_H1: {
+      farge: '#f46d43',
+      kode: 'NA_H1',
+      sti: 'NA/H/1',
+      tittel: { nb: 'Havvannmasser' },
     },
   },
   bbox: [[5.176, 58.107], [28.857, 70.144]],

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -70,7 +70,7 @@ const meta = {
   kode: 'NA_H',
   overordnet: [
     { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
-    { kode: '~', sti: '', tittel: { nb: 'Ratatouille' } },
+    { kode: '~', sti: '', tittel: { nb: 'NiN-kart' } },
   ],
   sti: 'NA/H',
   tittel: { nb: 'Marine vannmasser' },
@@ -105,7 +105,7 @@ const meta2 = {
   overordnet: [
     { kode: 'NA_M', sti: 'NA/M', tittel: { nb: 'Saltvannsbunnsystemer' } },
     { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
-    { kode: '~', sti: '', tittel: { nb: 'Ratatouille' } },
+    { kode: '~', sti: '', tittel: { nb: 'NiN-kart' } },
   ],
   prosedyrekategori: {
     kode: 'NA_HT-PK2',

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -256,7 +256,7 @@ storiesOf('KodeVindu', module)
 
 storiesOf('KodeVindu2', module)
   .addDecorator(muiTheme())
-  .add('default', () => (
+  .add('relasjon', () => (
     <KodeVindu
       data={api2}
       meta={meta2}

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -234,9 +234,6 @@ storiesOf('KodeVindu', module)
       language={['nb', 'la']}
     />
   ))
-
-storiesOf('KodeVindu2', module)
-  .addDecorator(muiTheme())
   .add('relasjon', () => (
     <KodeVindu
       data={api2}

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -89,7 +89,7 @@ const meta = {
   kode: 'NA_H',
   overordnet: [
     { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
-    { kode: '~', sti: '', tittel: { nb: 'Økologisk grunnkart' } },
+    { kode: '~', sti: '', tittel: { nb: 'Ratatouille' } },
   ],
   sti: 'NA/H',
   tittel: { nb: 'Marine vannmasser' },
@@ -124,7 +124,7 @@ const meta2 = {
   overordnet: [
     { kode: 'NA_M', sti: 'NA/M', tittel: { nb: 'Saltvannsbunnsystemer' } },
     { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
-    { kode: '~', sti: '', tittel: { nb: 'Økologisk grunnkart' } },
+    { kode: '~', sti: '', tittel: { nb: 'Ratatouille' } },
   ],
   prosedyrekategori: {
     kode: 'NA_HT-PK2',

--- a/src/Kodetre/Kodeliste/KodeVindu.stories.js
+++ b/src/Kodetre/Kodeliste/KodeVindu.stories.js
@@ -95,12 +95,171 @@ const meta = {
   tittel: { nb: 'Marine vannmasser' },
 }
 
+const api2 = {
+  kode: 'NA_M8',
+  navn: 'Helofytt-saltvannssump',
+  antallArter: 1,
+  antallNaturomrader: 381,
+  areal: 14444776.381085396,
+  forelder: { kode: 'NA_M', navn: 'Saltvannsbunnsystemer' },
+}
+const meta2 = {
+  bbox: [[4.955, 58.016], [29.999, 70.526]],
+  definisjonsgrunnlag: {
+    kode: 'NA_HT-DGA',
+    tittel: { nb: 'normal, strukturerende artsgruppe' },
+  },
+  farge: '#e6f598',
+  infoUrl: 'https://www.artsdatabanken.no/NiN2.0/M8',
+  ingress:
+    'Helofytt-saltvannssump omfatter tette bestander av makrohelofytter, det vil si storvokste sumpplanter med røttene i sublitoral bunn (som ikke tørrlegges ved lavvann), i vannstrandbeltet eller noe opp i landstrandbeltet.\n',
+  kode: 'NA_M8',
+  kunnskap: {
+    generelt: { kode: 'NA_HT-KG2', verdi: 2 },
+    inndeling: { kode: 'NA_HT-KG-GI2', verdi: 2 },
+  },
+  lkm: { u: ['MI_SA', 'MI_IO', 'MI_TV'] },
+  nin1: 'S7 [10, 12]',
+  nivå: 'hovedtype',
+  overordnet: [
+    { kode: 'NA_M', sti: 'NA/M', tittel: { nb: 'Saltvannsbunnsystemer' } },
+    { kode: 'NA', sti: 'NA', tittel: { nb: 'Natursystem' } },
+    { kode: '~', sti: '', tittel: { nb: 'Økologisk grunnkart' } },
+  ],
+  prosedyrekategori: {
+    kode: 'NA_HT-PK2',
+    tittel: {
+      nb:
+        'Med variasjon i artssammensetning betinget av strukturerende artsgruppe',
+    },
+  },
+  relasjon: {
+    dominerende_mengdeart: {
+      AR_100132: {
+        kode: 'AR_100132',
+        tittel: { la: 'Phragmites australis', nb: 'Takrør' },
+        variabel: 'dominerende mengdeart',
+      },
+    },
+    kjennetegnende_tyngdepunktart: {
+      AR_99475: {
+        kode: 'AR_99475',
+        tittel: { la: 'Iris pseudacorus', nb: 'Sverdlilje' },
+        variabel: 'kjennetegnende tyngdepunktart',
+      },
+      AR_99603: {
+        kode: 'AR_99603',
+        tittel: { la: 'Bolboschoenus maritimus', nb: 'Havsivaks' },
+        variabel: 'kjennetegnende tyngdepunktart',
+      },
+      AR_99698: {
+        kode: 'AR_99698',
+        tittel: { la: 'Carex paleacea', nb: 'Havstarr' },
+        variabel: 'kjennetegnende tyngdepunktart',
+      },
+      AR_99737: {
+        kode: 'AR_99737',
+        tittel: { la: 'Carex ×vacillans', nb: 'Saltstarr' },
+        variabel: 'kjennetegnende tyngdepunktart',
+      },
+      AR_99790: {
+        kode: 'AR_99790',
+        tittel: { la: 'Schoenoplectus tabernaemontani', nb: 'Pollsivaks' },
+        variabel: 'kjennetegnende tyngdepunktart',
+      },
+    },
+    mengdeart: {
+      AR_99603: {
+        kode: 'AR_99603',
+        tittel: { la: 'Bolboschoenus maritimus', nb: 'Havsivaks' },
+        variabel: '',
+      },
+    },
+    tyngdepunktart: {
+      AR_99677: {
+        kode: 'AR_99677',
+        tittel: { la: 'Carex mackenziei', nb: 'Pølstarr' },
+        variabel: '',
+      },
+    },
+    vanlig_art: {
+      AR_100058: {
+        kode: 'AR_100058',
+        tittel: { la: 'Glyceria fluitans', nb: 'Mannasøtgras' },
+        variabel: 'vanlig art',
+      },
+      AR_100061: {
+        kode: 'AR_100061',
+        tittel: { la: 'Glyceria maxima', nb: 'Kjempesøtgras' },
+        variabel: 'vanlig art',
+      },
+      AR_100132: {
+        kode: 'AR_100132',
+        tittel: { la: 'Phragmites australis', nb: 'Takrør' },
+        variabel: 'vanlig art',
+      },
+      AR_101845: {
+        kode: 'AR_101845',
+        tittel: { la: 'Lysimachia thyrsiflora', nb: 'Gulldusk' },
+        variabel: 'vanlig art',
+      },
+      AR_101846: {
+        kode: 'AR_101846',
+        tittel: { la: 'Lysimachia vulgaris', nb: 'Fredløs' },
+        variabel: 'vanlig art',
+      },
+      AR_102818: {
+        kode: 'AR_102818',
+        tittel: { la: 'Lythrum salicaria', nb: 'Kattehale' },
+        variabel: 'vanlig art',
+      },
+      AR_103183: {
+        kode: 'AR_103183',
+        tittel: { la: 'Thalictrum flavum', nb: 'Gul frøstjerne' },
+        variabel: 'vanlig art',
+      },
+      AR_103310: {
+        kode: 'AR_103310',
+        tittel: { la: 'Filipendula ulmaria', nb: 'Mjødurt' },
+        variabel: 'vanlig art',
+      },
+      AR_99722: {
+        kode: 'AR_99722',
+        tittel: { la: 'Carex salina', nb: 'Fjærestarr' },
+        variabel: 'vanlig art',
+      },
+      AR_99789: {
+        kode: 'AR_99789',
+        tittel: { la: 'Schoenoplectus lacustris', nb: 'Sjøsivaks' },
+        variabel: 'vanlig art',
+      },
+    },
+  },
+  sti: 'NA/M/8',
+  tittel: { nb: 'Helofytt-saltvannssump' },
+}
+
 storiesOf('KodeVindu', module)
   .addDecorator(muiTheme())
   .add('default', () => (
     <KodeVindu
       data={api}
       meta={meta}
+      onUpdateLayerProp={action('updateLayerProp')}
+      onMouseEnter={action('mouseEnter')}
+      onMouseLeave={action('mouseLeave')}
+      onClick={action('click')}
+      onFitBounds={action('onFitBounds')}
+      language={['nb', 'la']}
+    />
+  ))
+
+storiesOf('KodeVindu2', module)
+  .addDecorator(muiTheme())
+  .add('default', () => (
+    <KodeVindu
+      data={api2}
+      meta={meta2}
       onUpdateLayerProp={action('updateLayerProp')}
       onMouseEnter={action('mouseEnter')}
       onMouseLeave={action('mouseLeave')}

--- a/src/Kodetre/Kodeliste/Kodeliste.js
+++ b/src/Kodetre/Kodeliste/Kodeliste.js
@@ -74,8 +74,9 @@ const pad = sti => {
   const e = sti.split(/\//)
   if (!e) return ''
   const f = e.map(e => {
-    if (!e) return ''
-    return ('' + e.toString()).padStart(5, '0')
+    if (e && e.toString() && e.toString().padStart)
+      return e.toString().padStart(5, '0')
+    return ''
   })
   return f.join()
 }

--- a/src/Kodetre/Kodeliste/Kodeliste.js
+++ b/src/Kodetre/Kodeliste/Kodeliste.js
@@ -58,6 +58,7 @@ const Kodeliste = ({
             onMouseLeave={onMouseLeave}
             onUpdateLayerProp={onUpdateLayerProp}
             onShowColorpicker={() => onShowColorpicker(kode)}
+            showColor={onShowColorpicker}
             language={language}
             avatarUtenRamme={avatarUtenRamme}
           />

--- a/src/Kodetre/Kodeliste/Kodeliste.js
+++ b/src/Kodetre/Kodeliste/Kodeliste.js
@@ -75,7 +75,7 @@ const pad = sti => {
   if (!e) return ''
   const f = e.map(e => {
     if (!e) return ''
-    return e.toString().padStart(5, '0')
+    return ('' + e.toString()).padStart(5, '0')
   })
   return f.join()
 }

--- a/src/Kodetre/Kodeliste/Kodelisteelement.js
+++ b/src/Kodetre/Kodeliste/Kodelisteelement.js
@@ -99,9 +99,11 @@ class Kodelisteelement extends React.Component {
           onClick={() =>
             this.props.onGoToCode(meta && meta.sti ? meta.sti : kode)
           }
-          onMouseEnter={() => this.props.onMouseEnter(kode)}
+          onMouseEnter={() =>
+            this.props.onMouseEnter && this.props.onMouseEnter(kode)
+          }
           onMouseLeave={() => {
-            this.props.onMouseLeave(kode)
+            this.props.onMouseLeave && this.props.onMouseLeave(kode)
           }}
           leftAvatar={
             <Bildeavatar utenRamme={avatarUtenRamme} kode={meta.kode} />
@@ -121,17 +123,25 @@ class Kodelisteelement extends React.Component {
             meta.undertittel
           )}
           rightAvatar={
-            <div
-              style={{ display: 'inline-flex', position: 'absolute', top: 16 }}
-            >
-              <PaintSwatch
-                color={this.getFargeKode()}
-                onClick={e => {
-                  e.stopPropagation()
-                  this.props.onShowColorpicker(meta.kode)
+            this.props.showColor ? (
+              <div
+                style={{
+                  display: 'inline-flex',
+                  position: 'absolute',
+                  top: 16,
                 }}
-              />
-            </div>
+              >
+                <PaintSwatch
+                  color={this.getFargeKode()}
+                  onClick={e => {
+                    e.stopPropagation()
+                    this.props.onShowColorpicker(meta.kode)
+                  }}
+                />
+              </div>
+            ) : (
+              <div />
+            )
           }
         />
         <div style={{ marginLeft: 56 }}>

--- a/src/Kodetre/Kodeliste/ResultatListe.stories.js
+++ b/src/Kodetre/Kodeliste/ResultatListe.stories.js
@@ -90,8 +90,10 @@ const results2 = [
 storiesOf('Resultatliste', module).add('default', () => {
   return (
     <MuiThemeProvider>
-      <Resultatliste searchResults={results1} query="alk" />
-      <Resultatliste searchResults={results2} query="kjø" />
+      <div>
+        <Resultatliste searchResults={results1} query="alk" />
+        <Resultatliste searchResults={results2} query="kjø" />
+      </div>
     </MuiThemeProvider>
   )
 })

--- a/src/SearchBox/SearchBox.js
+++ b/src/SearchBox/SearchBox.js
@@ -24,7 +24,7 @@ export default class SearchBox extends Component {
         onKeyDown={this.onKeyDown}
         id={getNext()}
         value={query}
-        hintText={tittel ? tittel : 'Økologisk grunnkart'}
+        hintText={tittel ? tittel : 'Ratatouille'}
         onFocus={this.handleFocus}
         onChange={this.props.onQueryChange}
         fullWidth={true}

--- a/src/SearchBox/SearchBox.js
+++ b/src/SearchBox/SearchBox.js
@@ -24,7 +24,7 @@ export default class SearchBox extends Component {
         onKeyDown={this.onKeyDown}
         id={getNext()}
         value={query}
-        hintText={tittel ? tittel : 'Ratatouille'}
+        hintText={tittel ? tittel : 'NiN-kart'}
         onFocus={this.handleFocus}
         onChange={this.props.onQueryChange}
         fullWidth={true}

--- a/src/Storyshots.test.js
+++ b/src/Storyshots.test.js
@@ -21,6 +21,7 @@ var localStorageMock = (function() {
     },
   }
 })()
+
 Object.defineProperty(window, 'localStorage', { value: localStorageMock })
 
 initStoryshots()

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -207,7 +207,7 @@ exports[`Storyshots App Bar down into tree 1`] = `
                     }
                   }
                 >
-                  Økologisk grunnkart
+                  Ratatouille
                 </div>
                 <input
                   disabled={false}
@@ -651,7 +651,7 @@ exports[`Storyshots App Bar root 1`] = `
                     }
                   }
                 >
-                  Økologisk grunnkart
+                  Ratatouille
                 </div>
                 <input
                   disabled={false}
@@ -2555,7 +2555,7 @@ exports[`Storyshots Grunnkart Rot 1`] = `
                             }
                           }
                         >
-                          Økologisk grunnkart
+                          Ratatouille
                         </div>
                         <input
                           disabled={false}
@@ -3107,7 +3107,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                               <div
                                 onClick={[Function]}
                               >
-                                Økologisk grunnkart
+                                Ratatouille
                               </div>
                             </span>
                             <div
@@ -4551,7 +4551,7 @@ exports[`Storyshots KodeVindu2 relasjon 1`] = `
                               <div
                                 onClick={[Function]}
                               >
-                                Økologisk grunnkart
+                                Ratatouille
                               </div>
                             </span>
                             <div
@@ -11804,7 +11804,7 @@ exports[`Storyshots SearchBox default 1`] = `
               }
             }
           >
-            Økologisk grunnkart
+            Ratatouille
           </div>
           <input
             disabled={false}
@@ -13093,7 +13093,7 @@ exports[`Storyshots VenstreVindu Rot 1`] = `
                         }
                       }
                     >
-                      Økologisk grunnkart
+                      Ratatouille
                     </div>
                     <input
                       disabled={false}

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -207,7 +207,7 @@ exports[`Storyshots App Bar down into tree 1`] = `
                     }
                   }
                 >
-                  Ratatouille
+                  NiN-kart
                 </div>
                 <input
                   disabled={false}
@@ -651,7 +651,7 @@ exports[`Storyshots App Bar root 1`] = `
                     }
                   }
                 >
-                  Ratatouille
+                  NiN-kart
                 </div>
                 <input
                   disabled={false}
@@ -2555,7 +2555,7 @@ exports[`Storyshots Grunnkart Rot 1`] = `
                             }
                           }
                         >
-                          Ratatouille
+                          NiN-kart
                         </div>
                         <input
                           disabled={false}
@@ -3107,7 +3107,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                               <div
                                 onClick={[Function]}
                               >
-                                Ratatouille
+                                NiN-kart
                               </div>
                             </span>
                             <div
@@ -4551,7 +4551,7 @@ exports[`Storyshots KodeVindu2 relasjon 1`] = `
                               <div
                                 onClick={[Function]}
                               >
-                                Ratatouille
+                                NiN-kart
                               </div>
                             </span>
                             <div
@@ -11804,7 +11804,7 @@ exports[`Storyshots SearchBox default 1`] = `
               }
             }
           >
-            Ratatouille
+            NiN-kart
           </div>
           <input
             disabled={false}
@@ -13093,7 +13093,7 @@ exports[`Storyshots VenstreVindu Rot 1`] = `
                         }
                       }
                     >
-                      Ratatouille
+                      NiN-kart
                     </div>
                     <input
                       disabled={false}

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -4338,7 +4338,7 @@ exports[`Storyshots KodeVindu default 1`] = `
 </div>
 `;
 
-exports[`Storyshots KodeVindu2 default 1`] = `
+exports[`Storyshots KodeVindu2 relasjon 1`] = `
 <div
   style={
     Object {

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3428,7 +3428,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                       <div
                         style={
                           Object {
-                            "backgroundColor": "",
+                            "backgroundColor": "#DDDDDD",
                             "marginLeft": 0,
                             "muiPrepared": true,
                             "paddingBottom": 16,
@@ -3579,10 +3579,10 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "19.007609851593173%",
+                                  "width": "0%",
                                 }
                               }
-                              title="areal: 413 km²"
+                              title="areal: null"
                             />
                           </div>
                           <div
@@ -3807,10 +3807,10 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "100%",
+                                  "width": "2174024395.05291%",
                                 }
                               }
-                              title="areal: 2' km²"
+                              title="areal: 22' km²"
                             />
                           </div>
                           <div
@@ -3884,7 +3884,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                       <div
                         style={
                           Object {
-                            "backgroundColor": "",
+                            "backgroundColor": "#DDDDDD",
                             "marginLeft": 0,
                             "muiPrepared": true,
                             "paddingBottom": 16,
@@ -4035,10 +4035,10 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "65.059539361111%",
+                                  "width": "0%",
                                 }
                               }
-                              title="areal: 1' km²"
+                              title="areal: null"
                             />
                           </div>
                           <div
@@ -4112,7 +4112,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                       <div
                         style={
                           Object {
-                            "backgroundColor": "",
+                            "backgroundColor": "#DDDDDD",
                             "marginLeft": 0,
                             "muiPrepared": true,
                             "paddingBottom": 16,
@@ -4263,10 +4263,10 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "76.65251165580509%",
+                                  "width": "0%",
                                 }
                               }
-                              title="areal: 2' km²"
+                              title="areal: null"
                             />
                           </div>
                           <div

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -4338,7 +4338,7 @@ exports[`Storyshots KodeVindu default 1`] = `
 </div>
 `;
 
-exports[`Storyshots KodeVindu2 relasjon 1`] = `
+exports[`Storyshots KodeVindu relasjon 1`] = `
 <div
   style={
     Object {

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3300,7 +3300,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                   <span>
                      
                     <a
-                      href="https://www.artsdatabanken.no/NiN2.0/F1"
+                      href="https://www.artsdatabanken.no/NiN2.0/H"
                       style={
                         Object {
                           "color": "rgba(0,0,0,0.87)",
@@ -3499,7 +3499,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                               <div
                                 style={
                                   Object {
-                                    "backgroundColor": "#abdda4",
+                                    "backgroundColor": "#f46d43",
                                     "border": "1px solid hsla(0, 0%, 0%, 0.2)",
                                     "borderRadius": "50%",
                                     "bottom": 0,
@@ -3531,9 +3531,9 @@ exports[`Storyshots KodeVindu default 1`] = `
                               }
                             }
                           >
-                            H4
+                            H1
                           </div>
-                          Sterkt endrete marine vannmasser
+                          Havvannmasser
                           <div
                             style={
                               Object {
@@ -3579,7 +3579,235 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "76.65251165580509%",
+                                  "width": "19.007609851593173%",
+                                }
+                              }
+                              title="areal: 413 km²"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        >
+                          <div
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "height": "28px",
+                                "right": "14px",
+                                "top": "14px",
+                                "width": "28px",
+                              }
+                            }
+                          >
+                            <div
+                              style={
+                                Object {
+                                  "backgroundImage": "url(null)",
+                                  "borderRadius": "50%",
+                                  "bottom": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                }
+                              }
+                            >
+                              <div
+                                style={
+                                  Object {
+                                    "backgroundColor": "#fdae61",
+                                    "border": "1px solid hsla(0, 0%, 0%, 0.2)",
+                                    "borderRadius": "50%",
+                                    "bottom": 0,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "right": 0,
+                                    "top": 0,
+                                  }
+                                }
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "color": undefined,
+                                "float": "left",
+                                "fontWeight": 600,
+                                "paddingLeft": "2px",
+                                "paddingRight": "4px",
+                              }
+                            }
+                          >
+                            H2
+                          </div>
+                          Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "100%",
                                 }
                               }
                               title="areal: 2' km²"
@@ -3955,7 +4183,7 @@ exports[`Storyshots KodeVindu default 1`] = `
                               <div
                                 style={
                                   Object {
-                                    "backgroundColor": "#f46d43",
+                                    "backgroundColor": "#e6f598",
                                     "border": "1px solid hsla(0, 0%, 0%, 0.2)",
                                     "borderRadius": "50%",
                                     "bottom": 0,
@@ -3987,9 +4215,9 @@ exports[`Storyshots KodeVindu default 1`] = `
                               }
                             }
                           >
-                            H2
+                            H4
                           </div>
-                          Sirkulerende vannmasser i fysisk avgrensede saltvannsforekomster
+                          Sterkt endrete marine vannmasser
                           <div
                             style={
                               Object {
@@ -4035,238 +4263,10 @@ exports[`Storyshots KodeVindu default 1`] = `
                                   "float": "left",
                                   "height": 4,
                                   "marginTop": 4,
-                                  "width": "100%",
+                                  "width": "76.65251165580509%",
                                 }
                               }
                               title="areal: 2' km²"
-                            />
-                          </div>
-                          <div
-                            style={
-                              Object {
-                                "display": "inline",
-                                "float": "right",
-                                "position": "absolute",
-                                "right": 52,
-                              }
-                            }
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "marginLeft": 56,
-                    }
-                  }
-                />
-                <div>
-                  <span
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    open={null}
-                    style={
-                      Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                      }
-                    }
-                    tabIndex={0}
-                  >
-                    <div
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchStart={[Function]}
-                    >
-                      <div
-                        style={
-                          Object {
-                            "backgroundColor": "",
-                            "marginLeft": 0,
-                            "muiPrepared": true,
-                            "paddingBottom": 16,
-                            "paddingLeft": 72,
-                            "paddingRight": 56,
-                            "paddingTop": 20,
-                            "position": "relative",
-                          }
-                        }
-                      >
-                        <div
-                          className={undefined}
-                          onError={[Function]}
-                          size={40}
-                          style={
-                            Object {
-                              "alignItems": "center",
-                              "backgroundColor": "transparent",
-                              "borderRadius": "50%",
-                              "color": "#ffffff",
-                              "display": "inline-flex",
-                              "fontSize": 20,
-                              "height": 40,
-                              "justifyContent": "center",
-                              "left": 16,
-                              "muiPrepared": true,
-                              "position": "absolute",
-                              "top": 16,
-                              "userSelect": "none",
-                              "width": 40,
-                            }
-                          }
-                        />
-                        <div
-                          style={
-                            Object {
-                              "display": "inline-flex",
-                              "position": "absolute",
-                              "right": 16,
-                              "top": 16,
-                            }
-                          }
-                        >
-                          <div
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "height": "28px",
-                                "right": "14px",
-                                "top": "14px",
-                                "width": "28px",
-                              }
-                            }
-                          >
-                            <div
-                              style={
-                                Object {
-                                  "backgroundImage": "url(null)",
-                                  "borderRadius": "50%",
-                                  "bottom": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                }
-                              }
-                            >
-                              <div
-                                style={
-                                  Object {
-                                    "backgroundColor": "#abdda4",
-                                    "border": "1px solid hsla(0, 0%, 0%, 0.2)",
-                                    "borderRadius": "50%",
-                                    "bottom": 0,
-                                    "left": 0,
-                                    "position": "absolute",
-                                    "right": 0,
-                                    "top": 0,
-                                  }
-                                }
-                              />
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "muiPrepared": true,
-                            }
-                          }
-                        >
-                          <div
-                            style={
-                              Object {
-                                "color": undefined,
-                                "float": "left",
-                                "fontWeight": 600,
-                                "paddingLeft": "2px",
-                                "paddingRight": "4px",
-                              }
-                            }
-                          >
-                            H1
-                          </div>
-                          Havvannmasser
-                          <div
-                            style={
-                              Object {
-                                "display": "inline-flex",
-                              }
-                            }
-                          />
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "WebkitBoxOrient": null,
-                              "WebkitLineClamp": null,
-                              "color": "rgba(0, 0, 0, 0.54)",
-                              "display": null,
-                              "fontSize": 14,
-                              "height": 16,
-                              "lineHeight": "16px",
-                              "margin": 0,
-                              "marginTop": 4,
-                              "muiPrepared": true,
-                              "overflow": "hidden",
-                              "textOverflow": "ellipsis",
-                              "whiteSpace": "nowrap",
-                            }
-                          }
-                        >
-                          <div
-                            style={
-                              Object {
-                                "position": "relative",
-                                "width": 200,
-                              }
-                            }
-                          >
-                            <div
-                              className="sizebar"
-                              style={
-                                Object {
-                                  "backgroundColor": "#9e9e9e",
-                                  "borderBottomRightRadius": 10,
-                                  "borderTopRightRadius": 10,
-                                  "float": "left",
-                                  "height": 4,
-                                  "marginTop": 4,
-                                  "width": "19.007609851593173%",
-                                }
-                              }
-                              title="areal: 413 km²"
                             />
                           </div>
                           <div

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -5969,1674 +5969,1674 @@ exports[`Storyshots PunktinformasjonContainer default 1`] = `
 `;
 
 exports[`Storyshots Resultatliste default 1`] = `
-Array [
+<div>
   <div
     style={
-        Object {
-            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "backgroundColor": "#ffffff",
-            "borderRadius": 2,
-            "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
-                 0 1px 4px rgba(0, 0, 0, 0.12)",
-            "boxSizing": "border-box",
-            "color": "rgba(0, 0, 0, 0.87)",
-            "fontFamily": "Roboto, sans-serif",
-            "muiPrepared": true,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-          }
+      Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        "backgroundColor": "#ffffff",
+        "borderRadius": 2,
+        "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
+               0 1px 4px rgba(0, 0, 0, 0.12)",
+        "boxSizing": "border-box",
+        "color": "rgba(0, 0, 0, 0.87)",
+        "fontFamily": "Roboto, sans-serif",
+        "muiPrepared": true,
+        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+      }
     }
->
+  >
     <div
-        style={
-            Object {
-                "maxHeight": 494,
-                "muiPrepared": true,
-                "overflow": "hidden",
-                "padding": "8px 0px 8px 0px",
-                "paddingBottom": 0,
-                "paddingTop": 0,
-              }
+      style={
+        Object {
+          "maxHeight": 494,
+          "muiPrepared": true,
+          "overflow": "hidden",
+          "padding": "8px 0px 8px 0px",
+          "paddingBottom": 0,
+          "paddingTop": 0,
         }
+      }
     >
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
-                style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="KA"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
-                  }
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
             }
-        />
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="KA"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
     </div>
-</div>,
+  </div>
   <div
     style={
-        Object {
-            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "backgroundColor": "#ffffff",
-            "borderRadius": 2,
-            "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
-                 0 1px 4px rgba(0, 0, 0, 0.12)",
-            "boxSizing": "border-box",
-            "color": "rgba(0, 0, 0, 0.87)",
-            "fontFamily": "Roboto, sans-serif",
-            "muiPrepared": true,
-            "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-          }
+      Object {
+        "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+        "backgroundColor": "#ffffff",
+        "borderRadius": 2,
+        "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
+               0 1px 4px rgba(0, 0, 0, 0.12)",
+        "boxSizing": "border-box",
+        "color": "rgba(0, 0, 0, 0.87)",
+        "fontFamily": "Roboto, sans-serif",
+        "muiPrepared": true,
+        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+      }
     }
->
+  >
     <div
-        style={
-            Object {
-                "maxHeight": 494,
-                "muiPrepared": true,
-                "overflow": "hidden",
-                "padding": "8px 0px 8px 0px",
-                "paddingBottom": 0,
-                "paddingTop": 0,
-              }
+      style={
+        Object {
+          "maxHeight": 494,
+          "muiPrepared": true,
+          "overflow": "hidden",
+          "padding": "8px 0px 8px 0px",
+          "paddingBottom": 0,
+          "paddingTop": 0,
         }
+      }
     >
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
-                style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
-                  }
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
             }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
-                style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
                 Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
-                  }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
-                style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
                 }
-                tabIndex={0}
+              }
             >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
-                  }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+              <div
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "float": "right",
                   }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
                   }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "color": "#aaa",
                   }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
             }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "float": "right",
                   }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
                   }
-            }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "color": "#aaa",
                   }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
             }
-        />
-        <div>
-            <span
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                open={null}
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
                 style={
-                    Object {
-                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
-                        "background": "none",
-                        "backgroundColor": null,
-                        "border": 10,
-                        "boxSizing": "border-box",
-                        "color": "rgba(0, 0, 0, 0.87)",
-                        "cursor": "pointer",
-                        "display": "block",
-                        "fontFamily": "Roboto, sans-serif",
-                        "fontSize": 16,
-                        "fontWeight": "inherit",
-                        "height": 38,
-                        "lineHeight": "16px",
-                        "margin": 0,
-                        "muiPrepared": true,
-                        "outline": "none",
-                        "padding": 0,
-                        "paddingBottom": 1,
-                        "paddingTop": 0,
-                        "pointer": "hand",
-                        "position": "relative",
-                        "textDecoration": "none",
-                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
-                        "verticalAlign": null,
-                        "width": 392,
-                      }
-                }
-                tabIndex={0}
-            >
-                <div
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                >
-                    <div
-                        style={
-                            Object {
-                                "fontSize": 13,
-                                "fontWeight": 500,
-                                "lineheight": 24,
-                                "marginLeft": 0,
-                                "muiPrepared": true,
-                                "overflow": "hidden",
-                                "paddingBottom": 11,
-                                "paddingLeft": 66,
-                                "paddingRight": 16,
-                                "paddingTop": 11,
-                                "position": "relative",
-                                "textOverflow": "ellipsis",
-                                "whiteSpace": "nowrap",
-                              }
-                        }
-                    >
-                        <div
-                            style={
-                                Object {
-                                    "float": "right",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </div>
-                        <img
-                            alt="AR"
-                            color="#757575"
-                            onError={[Function]}
-                            src={undefined}
-                            style={
-                                Object {
-                                    "display": "block",
-                                    "height": 24,
-                                    "left": 4,
-                                    "margin": 12,
-                                    "marginLeft": 16,
-                                    "marginTop": 6,
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "width": 24,
-                                  }
-                            }
-                        />
-                        <span>
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                         
-                        <span
-                            style={
-                                Object {
-                                    "color": "#aaa",
-                                  }
-                            }
-                        >
-                             
-                            <span
-                                style={Object {}}
-                            >
-                                
-                            </span>
-                             
-                        </span>
-                    </div>
-                </div>
-            </span>
-        </div>
-        <hr
-            style={
-                Object {
-                    "backgroundColor": "#e0e0e0",
-                    "border": "none",
-                    "height": 1,
-                    "margin": 0,
-                    "marginLeft": 72,
-                    "marginTop": -1,
-                    "muiPrepared": true,
+                  Object {
+                    "float": "right",
                   }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
             }
-        />
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
+      <div>
+        <span
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          open={null}
+          style={
+            Object {
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "background": "none",
+              "backgroundColor": null,
+              "border": 10,
+              "boxSizing": "border-box",
+              "color": "rgba(0, 0, 0, 0.87)",
+              "cursor": "pointer",
+              "display": "block",
+              "fontFamily": "Roboto, sans-serif",
+              "fontSize": 16,
+              "fontWeight": "inherit",
+              "height": 38,
+              "lineHeight": "16px",
+              "margin": 0,
+              "muiPrepared": true,
+              "outline": "none",
+              "padding": 0,
+              "paddingBottom": 1,
+              "paddingTop": 0,
+              "pointer": "hand",
+              "position": "relative",
+              "textDecoration": "none",
+              "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+              "verticalAlign": null,
+              "width": 392,
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+          >
+            <div
+              style={
+                Object {
+                  "fontSize": 13,
+                  "fontWeight": 500,
+                  "lineheight": 24,
+                  "marginLeft": 0,
+                  "muiPrepared": true,
+                  "overflow": "hidden",
+                  "paddingBottom": 11,
+                  "paddingLeft": 66,
+                  "paddingRight": 16,
+                  "paddingTop": 11,
+                  "position": "relative",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "float": "right",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </div>
+              <img
+                alt="AR"
+                color="#757575"
+                onError={[Function]}
+                src={undefined}
+                style={
+                  Object {
+                    "display": "block",
+                    "height": 24,
+                    "left": 4,
+                    "margin": 12,
+                    "marginLeft": 16,
+                    "marginTop": 6,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 24,
+                  }
+                }
+              />
+              <span>
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+               
+              <span
+                style={
+                  Object {
+                    "color": "#aaa",
+                  }
+                }
+              >
+                 
+                <span
+                  style={Object {}}
+                >
+                  
+                </span>
+                 
+              </span>
+            </div>
+          </div>
+        </span>
+      </div>
+      <hr
+        style={
+          Object {
+            "backgroundColor": "#e0e0e0",
+            "border": "none",
+            "height": 1,
+            "margin": 0,
+            "marginLeft": 72,
+            "marginTop": -1,
+            "muiPrepared": true,
+          }
+        }
+      />
     </div>
-</div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Storyshots SearchBox default 1`] = `

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -4338,6 +4338,4094 @@ exports[`Storyshots KodeVindu default 1`] = `
 </div>
 `;
 
+exports[`Storyshots KodeVindu2 default 1`] = `
+<div
+  style={
+    Object {
+      "background": "#ffffff",
+      "bottom": 0,
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    className="SplitPane  vertical "
+    style={
+      Object {
+        "MozUserSelect": "text",
+        "WebkitUserSelect": "text",
+        "display": "flex",
+        "flex": 1,
+        "flexDirection": "row",
+        "height": "100%",
+        "left": 0,
+        "msUserSelect": "text",
+        "outline": "none",
+        "overflow": "hidden",
+        "position": "absolute",
+        "right": 0,
+        "userSelect": "text",
+      }
+    }
+  >
+    <div
+      className="Pane vertical Pane1  "
+      style={
+        Object {
+          "flex": 1,
+          "outline": "none",
+          "overflowX": "auto",
+          "overflowY": "auto",
+          "position": "relative",
+        }
+      }
+    >
+      <div>
+        <div>
+          <div>
+            <div
+              isloading={undefined}
+              message={undefined}
+              style={
+                Object {
+                  "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 2,
+                  "boxShadow": "0 14px 45px rgba(0, 0, 0, 0.25),
+                         0 10px 18px rgba(0, 0, 0, 0.22)",
+                  "boxSizing": "border-box",
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontFamily": "Roboto, sans-serif",
+                  "height": "100%",
+                  "left": 0,
+                  "muiPrepared": true,
+                  "overflow": "auto",
+                  "position": "fixed",
+                  "top": 0,
+                  "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                  "width": 408,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 2,
+                    "boxShadow": "0 1px 6px rgba(0, 0, 0, 0.12),
+                           0 1px 4px rgba(0, 0, 0, 0.12)",
+                    "boxSizing": "border-box",
+                    "color": "rgba(0, 0, 0, 0.87)",
+                    "fontFamily": "Roboto, sans-serif",
+                    "muiPrepared": true,
+                    "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                    "zIndex": 1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "paddingBottom": 0,
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "height": 297,
+                        "maxHeight": 297,
+                        "muiPrepared": true,
+                        "position": "relative",
+                      }
+                    }
+                  >
+                    <div
+                      style={
+                        Object {
+                          "muiPrepared": true,
+                        }
+                      }
+                    >
+                      <img
+                        alt=""
+                        onError={[Function]}
+                        src={undefined}
+                        srcSet="undefined 1.5x, undefined 2x"
+                        style={
+                          Object {
+                            "height": 297,
+                            "maxHeight": 297,
+                            "maxWidth": "100%",
+                            "minHeight": 297,
+                            "minWidth": "100%",
+                            "muiPrepared": true,
+                            "objectFit": "cover",
+                            "verticalAlign": "top",
+                            "width": "100%",
+                          }
+                        }
+                      />
+                    </div>
+                    <div
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "muiPrepared": true,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                        }
+                      }
+                    >
+                      <div
+                        style={
+                          Object {
+                            "height": "100%",
+                            "muiPrepared": true,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          style={
+                            Object {
+                              "background": "rgba(0, 0, 0, 0.54)",
+                              "bottom": 0,
+                              "left": 0,
+                              "muiPrepared": true,
+                              "paddingTop": 8,
+                              "position": "absolute",
+                              "right": 0,
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "muiPrepared": true,
+                                "padding": 16,
+                                "position": "relative",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "color": "#ffffff",
+                                  "display": "block",
+                                  "fontSize": 24,
+                                  "lineHeight": "36px",
+                                  "muiPrepared": true,
+                                }
+                              }
+                            >
+                              Helofytt-saltvannssump
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "color": "#ffffff",
+                                  "cursor": "pointer",
+                                  "display": "block",
+                                  "fontSize": 14,
+                                  "muiPrepared": true,
+                                }
+                              }
+                            >
+                              <div
+                                onClick={[Function]}
+                              >
+                                Saltvannsbunnsystemer
+                              </div>
+                              <div
+                                onClick={[Function]}
+                              >
+                                Natursystem
+                              </div>
+                              <div
+                                onClick={[Function]}
+                              >
+                                Økologisk grunnkart
+                              </div>
+                            </span>
+                            <div
+                              style={
+                                Object {
+                                  "bottom": -8,
+                                  "muiPrepared": true,
+                                  "padding": 8,
+                                  "position": "absolute",
+                                  "right": 0,
+                                }
+                              }
+                            >
+                              <button
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOut={[Function]}
+                                onTouchStart={[Function]}
+                                style={
+                                  Object {
+                                    "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                                    "background": "none",
+                                    "border": 10,
+                                    "boxSizing": "border-box",
+                                    "cursor": "pointer",
+                                    "display": "inline-block",
+                                    "float": "right",
+                                    "fontFamily": "Roboto, sans-serif",
+                                    "fontSize": 0,
+                                    "fontWeight": "inherit",
+                                    "height": 48,
+                                    "margin": 0,
+                                    "marginRight": 8,
+                                    "muiPrepared": true,
+                                    "outline": "none",
+                                    "overflow": "visible",
+                                    "padding": 12,
+                                    "position": "relative",
+                                    "textDecoration": "none",
+                                    "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                                    "verticalAlign": null,
+                                    "width": 48,
+                                  }
+                                }
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <div
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchStart={[Function]}
+                                >
+                                  <svg
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    style={
+                                      Object {
+                                        "color": "rgba(0, 0, 0, 0.87)",
+                                        "display": "inline-block",
+                                        "fill": "#eee",
+                                        "height": 24,
+                                        "muiPrepared": true,
+                                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                                        "userSelect": "none",
+                                        "width": 24,
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+                                    />
+                                  </svg>
+                                </div>
+                              </button>
+                              <button
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseOut={[Function]}
+                                onTouchStart={[Function]}
+                                style={
+                                  Object {
+                                    "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                                    "background": "none",
+                                    "border": 10,
+                                    "boxSizing": "border-box",
+                                    "cursor": "pointer",
+                                    "display": "inline-block",
+                                    "float": "right",
+                                    "fontFamily": "Roboto, sans-serif",
+                                    "fontSize": 0,
+                                    "fontWeight": "inherit",
+                                    "height": 48,
+                                    "margin": 0,
+                                    "marginRight": 8,
+                                    "muiPrepared": true,
+                                    "outline": "none",
+                                    "overflow": "visible",
+                                    "padding": 12,
+                                    "position": "relative",
+                                    "textDecoration": "none",
+                                    "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                                    "verticalAlign": null,
+                                    "width": 48,
+                                  }
+                                }
+                                tabIndex={0}
+                                type="button"
+                              >
+                                <div
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchStart={[Function]}
+                                >
+                                  <svg
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    style={
+                                      Object {
+                                        "color": "rgba(0, 0, 0, 0.87)",
+                                        "display": "inline-block",
+                                        "fill": "#eee",
+                                        "height": 24,
+                                        "muiPrepared": true,
+                                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                                        "userSelect": "none",
+                                        "width": 24,
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"
+                                    />
+                                  </svg>
+                                </div>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "padding": 24,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 18,
+                      "paddingBottom": 24,
+                    }
+                  }
+                >
+                  Fakta
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(0,0,0,0.87)",
+                      "fontSize": 13,
+                    }
+                  }
+                >
+                  Helofytt-saltvannssump omfatter tette bestander av makrohelofytter, det vil si storvokste sumpplanter med røttene i sublitoral bunn (som ikke tørrlegges ved lavvann), i vannstrandbeltet eller noe opp i landstrandbeltet.
+                  
+                  <span>
+                     
+                    <a
+                      href="https://www.artsdatabanken.no/NiN2.0/M8"
+                      style={
+                        Object {
+                          "color": "rgba(0,0,0,0.87)",
+                        }
+                      }
+                      target="top"
+                    >
+                      Artsdatabanken
+                    </a>
+                  </span>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "fontSize": 13,
+                    "lineHeight": "1.5em",
+                    "paddingLeft": 24,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  Areal
+                  : 
+                </span>
+                495 km² (i 381 områder)
+              </div>
+              <div
+                style={
+                  Object {
+                    "fontSize": 13,
+                    "lineHeight": "1.5em",
+                    "paddingLeft": 24,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "fontWeight": 700,
+                    }
+                  }
+                >
+                  Arter observert
+                  : 
+                </span>
+                1
+              </div>
+              <div
+                style={
+                  Object {
+                    "muiPrepared": true,
+                    "padding": "8px 0px 8px 0px",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Definisjon
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "color": undefined,
+                                "float": "left",
+                                "fontWeight": 600,
+                                "paddingLeft": "2px",
+                                "paddingRight": "4px",
+                              }
+                            }
+                          >
+                            A
+                          </div>
+                          normal, strukturerende artsgruppe
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          Definisjon
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "color": undefined,
+                                "float": "left",
+                                "fontWeight": 600,
+                                "paddingLeft": "2px",
+                                "paddingRight": "4px",
+                              }
+                            }
+                          >
+                            K2
+                          </div>
+                          Med variasjon i artssammensetning betinget av strukturerende artsgruppe
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          Prosedyrekategori
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Mengdearter
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(95, 95, 95, 0.54)",
+                      "fontSize": "14px",
+                      "padding": "0px 5px 0px 16px",
+                    }
+                  }
+                >
+                  Art med gjennomsnittlig dekning eller biomasseandel større enn 1/8 i et utvalg av enkeltobservasjonsenheter.
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Havsivaks (Bolboschoenus maritimus)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Dominerende mengdearter
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(95, 95, 95, 0.54)",
+                      "fontSize": "14px",
+                      "padding": "0px 5px 0px 16px",
+                    }
+                  }
+                >
+                  Art med gjennomsnittlig dekning eller biomasseandel større enn 1/4 i et utvalg av enkeltobservasjonsenheter.
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Takrør (Phragmites australis)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Vanlige arter
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(95, 95, 95, 0.54)",
+                      "fontSize": "14px",
+                      "padding": "0px 5px 0px 16px",
+                    }
+                  }
+                >
+                  Art med frekvens større enn 1/8 i et utvalg enkeltobservasjonsenheter. For at en art skal være «vanlig», må den tilfredsstille dette kravet om frekvens &gt; 1/8 i hele naturtypens utbredelsesområde, ikke bare innenfor artens utbredelsesområde.
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Sjøsivaks (Schoenoplectus lacustris)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Fjærestarr (Carex salina)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Mjødurt (Filipendula ulmaria)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Gul frøstjerne (Thalictrum flavum)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Kattehale (Lythrum salicaria)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Fredløs (Lysimachia vulgaris)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Gulldusk (Lysimachia thyrsiflora)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Takrør (Phragmites australis)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Kjempesøtgras (Glyceria maxima)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Mannasøtgras (Glyceria fluitans)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Tyngdepunktarter
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(95, 95, 95, 0.54)",
+                      "fontSize": "14px",
+                      "padding": "0px 5px 0px 16px",
+                    }
+                  }
+                >
+                  Art med høyere frekvens og dekning i en aktuell naturtype (hovedtype eller grunntype) enn i et sammenliknbart utvalg typer
+                                    (f.eks. andre hovedtyper som tilhører samme hovedtypegruppe eller andre grunntyper som tilhører samme hovedtype
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Pølstarr (Carex mackenziei)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "boxSizing": "border-box",
+                      "color": "rgba(0, 0, 0, 0.54)",
+                      "fontSize": 14,
+                      "fontWeight": 500,
+                      "lineHeight": "48px",
+                      "muiPrepared": true,
+                      "paddingLeft": 16,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  Kjennetegnende tyngdepunktarter
+                </div>
+                <div
+                  style={
+                    Object {
+                      "color": "rgba(95, 95, 95, 0.54)",
+                      "fontSize": "14px",
+                      "padding": "0px 5px 0px 16px",
+                    }
+                  }
+                >
+                  Tyngdepunktart som utelukkende eller nesten utelukkende forekommer i en naturtype eller gruppe av naturtyper på et eller annet generaliseringsnivå
+                </div>
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Pollsivaks (Schoenoplectus tabernaemontani)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Saltstarr (Carex ×vacillans)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Havstarr (Carex paleacea)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Havsivaks (Bolboschoenus maritimus)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+                <div>
+                  <span
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    open={null}
+                    style={
+                      Object {
+                        "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                        "background": "none",
+                        "backgroundColor": null,
+                        "border": 10,
+                        "boxSizing": "border-box",
+                        "color": "rgba(0, 0, 0, 0.87)",
+                        "cursor": "pointer",
+                        "display": "block",
+                        "fontFamily": "Roboto, sans-serif",
+                        "fontSize": 16,
+                        "fontWeight": "inherit",
+                        "lineHeight": "16px",
+                        "margin": 0,
+                        "muiPrepared": true,
+                        "outline": "none",
+                        "padding": 0,
+                        "position": "relative",
+                        "textDecoration": "none",
+                        "transition": "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
+                        "verticalAlign": null,
+                      }
+                    }
+                    tabIndex={0}
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "backgroundColor": "#DDDDDD",
+                            "marginLeft": 0,
+                            "muiPrepared": true,
+                            "paddingBottom": 16,
+                            "paddingLeft": 72,
+                            "paddingRight": 56,
+                            "paddingTop": 20,
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <div
+                          className={undefined}
+                          onError={[Function]}
+                          size={40}
+                          style={
+                            Object {
+                              "alignItems": "center",
+                              "backgroundColor": "transparent",
+                              "borderRadius": "50%",
+                              "color": "#ffffff",
+                              "display": "inline-flex",
+                              "fontSize": 20,
+                              "height": 40,
+                              "justifyContent": "center",
+                              "left": 16,
+                              "muiPrepared": true,
+                              "position": "absolute",
+                              "top": 16,
+                              "userSelect": "none",
+                              "width": 40,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                              "right": 16,
+                              "top": 16,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "muiPrepared": true,
+                            }
+                          }
+                        >
+                          Sverdlilje (Iris pseudacorus)
+                          <div
+                            style={
+                              Object {
+                                "display": "inline-flex",
+                              }
+                            }
+                          />
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "WebkitBoxOrient": null,
+                              "WebkitLineClamp": null,
+                              "color": "rgba(0, 0, 0, 0.54)",
+                              "display": null,
+                              "fontSize": 14,
+                              "height": 16,
+                              "lineHeight": "16px",
+                              "margin": 0,
+                              "marginTop": 4,
+                              "muiPrepared": true,
+                              "overflow": "hidden",
+                              "textOverflow": "ellipsis",
+                              "whiteSpace": "nowrap",
+                            }
+                          }
+                        >
+                          <div
+                            style={
+                              Object {
+                                "position": "relative",
+                                "width": 200,
+                              }
+                            }
+                          >
+                            <div
+                              className="sizebar"
+                              style={
+                                Object {
+                                  "backgroundColor": "#9e9e9e",
+                                  "borderBottomRightRadius": 10,
+                                  "borderTopRightRadius": 10,
+                                  "float": "left",
+                                  "height": 4,
+                                  "marginTop": 4,
+                                  "width": "0%",
+                                }
+                              }
+                              title="areal: null"
+                            />
+                          </div>
+                          <div
+                            style={
+                              Object {
+                                "display": "inline",
+                                "float": "right",
+                                "position": "absolute",
+                                "right": 52,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "marginLeft": 56,
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      className="Resizer vertical "
+      onClick={[Function]}
+      onDoubleClick={[Function]}
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "cursor": "col-resize",
+          "marginRight": -6,
+          "width": 10,
+          "zIndex": 1,
+        }
+      }
+    />
+    <div
+      className="Pane vertical Pane2  "
+      style={
+        Object {
+          "flex": "none",
+          "outline": "none",
+          "position": "relative",
+          "width": 0,
+        }
+      }
+    >
+      <div
+        className="sb-addon-material-ui-theme_sidebar"
+        style={
+          Object {
+            "height": "100%",
+            "width": "100%",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Kodetagg Rødliste 1`] = `
 <div
   style={


### PR DESCRIPTION
fjernet fargesymbol på listeelement for meta.relasjon-listene

## A picture tells a thousand words

## Before this PR
![image](https://user-images.githubusercontent.com/13641108/38498273-2225cc1c-3c04-11e8-8d70-0d5e58cd65dc.png)

## After this PR
![image](https://user-images.githubusercontent.com/13641108/38498295-39c2e1c0-3c04-11e8-8d0e-fb4b7df33e49.png)
