### PR TITLE
fix #342: Nullstill meta når man går ut av /katalog/ for å fjerne aktivt lag-filteret

### DIFF
--- a/src/Grunnkart/Grunnkart.js
+++ b/src/Grunnkart/Grunnkart.js
@@ -154,6 +154,7 @@ class Grunnkart extends React.Component<Props, State> {
     url = url.toLowerCase()
     let kodematch = url.match(/\/katalog\/(.*)/)
     if (!kodematch || kodematch.length !== 2) {
+      this.setState({ meta: '' })
       return
     }
 


### PR DESCRIPTION

## A picture tells a thousand words

## Before this PR

## After this PR
![image](https://user-images.githubusercontent.com/13641108/39757937-ae611e80-52ce-11e8-888c-0a6631d4415b.png)
![image](https://user-images.githubusercontent.com/13641108/39757948-bc61241c-52ce-11e8-9c6f-c182061749ac.png)
