### PR TITLE
scroll på aktivt-kartlag-vindu om det blir for stort, ikke scroll på …

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,3 +17,7 @@
   -o-transition: width 0.5s ease-out;
   transition: width 0.5s ease-out;
 }
+
+body {
+  overflow: hidden;
+}

--- a/src/Grunnkart/Grunnkart.js
+++ b/src/Grunnkart/Grunnkart.js
@@ -320,8 +320,11 @@ class Grunnkart extends React.Component<Props, State> {
               position: 'absolute',
               left: 8,
               top: 10,
+              paddingBottom: 8,
               width: 392,
               zIndex: 2,
+              maxHeight: window.innerHeight - 10,
+              overflowY: 'auto',
             }}
           >
             <VenstreVinduContainer

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3621,6 +3621,9 @@ exports[`Storyshots Grunnkart Rot 1`] = `
                 Object {
                   "backgroundColor": "#fff",
                   "left": 8,
+                  "maxHeight": 758,
+                  "overflowY": "auto",
+                  "paddingBottom": 8,
                   "position": "absolute",
                   "top": 10,
                   "width": 392,


### PR DESCRIPTION
…hele skjermbildet

## A picture tells a thousand words

## Before this PR
![image](https://user-images.githubusercontent.com/13641108/40705170-78adfb00-63ea-11e8-87cd-1c50034f0f4d.png)

## After this PR
![image](https://user-images.githubusercontent.com/13641108/40705231-983eb32e-63ea-11e8-8434-a51fef98c51d.png)
