### PR TITLE
fix(color): fix#185: Ta hensyn til custom transparency for valgte lag

### DIFF
--- a/src/Kart/Mapbox/index.js
+++ b/src/Kart/Mapbox/index.js
@@ -289,7 +289,9 @@ class Mapbox extends Component {
       let lag = hentLag(map, item.kode)
       if (!lag || !lag.paint) return
 
-      let fillColor = Color(item.farge || '#ff2222').alpha(0.7)
+      let fillColor = item.farge
+        ? Color(item.farge)
+        : Color('#ff2222').alpha(0.7)
       lag.paint['fill-color'] = fillColor.rgbaString()
       lag.paint['fill-outline-color'] = Color('#ffffff').rgbaString()
       lag.id = lagId


### PR DESCRIPTION
## A picture tells a thousand words

## Before this PR

## After this PR
![image](https://user-images.githubusercontent.com/13641108/41232027-4f2326c6-6d85-11e8-8f40-83acd247bc29.png)
