### PR TITLE
revert use of react-meta-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-content-loader": "^3.1.2",
     "react-dom": "^16.2.0",
     "react-map-gl": "^3.1.5",
-    "react-meta-tags": "^0.4.1",
     "react-responsive": "^5.0.0",
     "react-router-dom": "^4.2.2",
     "react-scripts": "^1.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=0">
   <meta name="theme-color" content="#000000">
   <!--
       manifest.json provides metadata used when your web app is added to the

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from 'react-router-dom'
 import { getMuiTheme, MuiThemeProvider } from 'material-ui/styles'
 import Grunnkart from './Grunnkart/Grunnkart'
 import './App.css'
-import MetaTags from 'react-meta-tags'
 
 const muiTheme = getMuiTheme({
   palette: {
@@ -28,19 +27,11 @@ const muiTheme = getMuiTheme({
 class App extends Component {
   render() {
     return (
-      <div class="wrapper">
-        <MetaTags>
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=0"
-          />
-        </MetaTags>
-        <MuiThemeProvider muiTheme={muiTheme}>
-          <BrowserRouter>
-            <Grunnkart />
-          </BrowserRouter>
-        </MuiThemeProvider>
-      </div>
+      <MuiThemeProvider muiTheme={muiTheme}>
+        <BrowserRouter>
+          <Grunnkart />
+        </BrowserRouter>
+      </MuiThemeProvider>
     )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8260,13 +8260,6 @@ react-material-color-picker@^1.1.2:
     babel-runtime "^6.5.0"
     prop-types "^15.6.0"
 
-react-meta-tags@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/react-meta-tags/-/react-meta-tags-0.4.1.tgz#bbb2bc7a5b8b7faa73569b742517f9075d692db6"
-  dependencies:
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
-
 react-modal@^3.1.10:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.11.tgz#95c8223fcee7013258ad2d149c38c9f870c89958"


### PR DESCRIPTION
move metaTag to index.html

## A picture tells a thousand words

## Before this PR
Uses react-meta-tags

## After this PR
Meta-tags set in index.html