### PR TITLE
Fix: Setting pre-commit script in package.json > scripts will be depr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --coverage",
     "test:watch": "node scripts/test.js",
-    "precommit": "pretty-quick --staged",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public -o build/storybook",
     "report-coverage": "coveralls < coverage/lcov.info"
@@ -163,5 +162,10 @@
   "contributors": [
     "Bjørn Reppen <bjreppen@gmail.com>",
     "Jarle Pedersen <jarle.pedersen@norconsult.com>"
-  ]
+  ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  }
 }


### PR DESCRIPTION
Moved husky hooks to to husky.hooks.

```
Warning: Setting pre-commit script in package.json > scripts will be deprecated
Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
Or run ./node_modules/.bin/husky-upgrade for automatic update

See https://github.com/typicode/husky for usage
```