### PR TITLE
Fix typography deprecation warning

### DIFF
--- a/src/Grunnkart/AktiveKartlagKnapp.js
+++ b/src/Grunnkart/AktiveKartlagKnapp.js
@@ -53,7 +53,7 @@ class AktiveKartlagKnapp extends React.Component<Props, State> {
                 fontSize: 15,
                 fontWeight: 500,
               }}
-              variant="title"
+              variant="h6"
               color="inherit"
             >
               Aktive kartlag


### PR DESCRIPTION
Fix console error: "index.js:1452 Warning: Failed prop type: You are using a deprecated typography variant: `title` that will be removed in the next major release."